### PR TITLE
`brew audit` のエラーを解消する

### DIFF
--- a/Casks/voicevox-preview.rb
+++ b/Casks/voicevox-preview.rb
@@ -1,8 +1,8 @@
 cask "voicevox-preview" do
   version "0.15.0-preview.3"
-  sha256 "5584c1c3ce8b32a58ccd7c8744aaeb00de484d36fe5e49a2b6721e033232ba64"
+  sha256 "6da0518dfb3aa00e588fa839ebccff0339b627824ccd038304e8dbfcd751dbf1"
 
-  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/voicevox-macos-cpu-#{version}.zip",
+  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.dmg",
       verified: "github.com/VOICEVOX/voicevox/"
   name "VOICEVOX"
   desc "Free, medium-quality text-to-speech software"

--- a/Casks/voicevox-preview.rb
+++ b/Casks/voicevox-preview.rb
@@ -9,7 +9,7 @@ cask "voicevox-preview" do
   homepage "https://voicevox.hiroshiba.jp/"
 
   livecheck do
-    url :url
+    url "https://github.com/VOICEVOX/voicevox/releases?q=prerelease%3Atrue&expanded=true"
     regex(/(\d+(?:\.\d+)*-preview\.\d+)$/i)
   end
 

--- a/Casks/voicevox-preview.rb
+++ b/Casks/voicevox-preview.rb
@@ -1,8 +1,8 @@
 cask "voicevox-preview" do
   version "0.15.0-preview.3"
-  sha256 "6da0518dfb3aa00e588fa839ebccff0339b627824ccd038304e8dbfcd751dbf1"
+  sha256 "5584c1c3ce8b32a58ccd7c8744aaeb00de484d36fe5e49a2b6721e033232ba64"
 
-  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.dmg",
+  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/voicevox-macos-cpu-#{version}.zip",
       verified: "github.com/VOICEVOX/voicevox/"
   name "VOICEVOX"
   desc "Free, medium-quality text-to-speech software"

--- a/Casks/voicevox-preview.rb
+++ b/Casks/voicevox-preview.rb
@@ -1,8 +1,8 @@
 cask "voicevox-preview" do
-  version "0.15.0-preview.3"
+  version "15.0-preview.3"
   sha256 "6da0518dfb3aa00e588fa839ebccff0339b627824ccd038304e8dbfcd751dbf1"
 
-  url "https://github.com/VOICEVOX/voicevox/releases/download/#{version}/VOICEVOX.dmg",
+  url "https://github.com/VOICEVOX/voicevox/releases/download/0.#{version}/VOICEVOX.dmg",
       verified: "github.com/VOICEVOX/voicevox/"
   name "VOICEVOX"
   desc "Free, medium-quality text-to-speech software"


### PR DESCRIPTION
`brew audit` で以下のエラーが出るのをなんとかする。

```sh
$ brew audit --cask --online --signing 'voicevox-preview'
...
audit for voicevox-preview: failed
Error: 1 problem in 1 cask detected.
 - 0.[15](https://github.com/umi1299/homebrew-voicevox/actions/runs/5754647677/job/15600426677#step:11:16).0-preview.3 is a GitHub pre-release.
umi1299/voicevox/voicevox-preview
  * line 5, col 2: 0.15.0-preview.3 is a GitHub pre-release.
Error: 0.15.0-preview.3 is a GitHub pre-release.
Error: Process completed with exit code 1.
```